### PR TITLE
13 - Extra Secure Mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,18 @@
 {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": false,
+    "Lua.workspace.library": [
+        "${addons}/garrysmod/module/library"
+    ],
+    "Lua.runtime.version": "LuaJIT",
+    "Lua.runtime.special": {
+        "include": "dofile",
+        "IncludeCS": "dofile"
+    },
+    "Lua.runtime.nonstandardSymbol": [
+        "continue"
+    ],
+    "Lua.diagnostics.disable": [
+        "duplicate-set-field"
+    ],
+    "Lua.workspace.checkThirdParty": false
 }


### PR DESCRIPTION
This automatically wraps outputs coming out of sf functions, and makes inputs to them immutable.

It's disabled by default but that may change. The convar is `sf_extra_secure`.

This should make it significantly harder for an addon author to screw something up, although it's still possible. This could be sped up dramatically if we used the documentation we have on functions, to avoid usage of unpack() and to potentially use the specific unwraps instead of object unwrapping.

Could also inline the use of instance.Sanitize.

Example cases solved by this:

```lua
function timer_library.bad()
    return Vector() -- this automatically gets wrapped
end

function instance.Types.Vector.Methods:bad()
    return Vector() -- this automatically gets wrapped
end

function timer_library.bad2(a)
    a.b = Vector()
    print("I got a value here", a.b) -- this value exists here but isn't ever passed to the user. 'a' is an indirect table.
end
```