### PR TITLE
hello world (Add missing IGModAudioChannel methods to BASS)

### DIFF
--- a/lua/starfall/examples/music_player.lua
+++ b/lua/starfall/examples/music_player.lua
@@ -19,11 +19,56 @@ else
 		end
 
 		bass.loadURL(songURL, "3d noblock", function(snd, err, errtxt)
-			if snd then
+			if isValid(snd) then
 				song = snd
 				snd:setFade(500, 2000)
 				snd:setVolume(2)
 				pcall(snd.setLooping, snd, true) -- pcall in case of audio stream
+
+				-- CRITICAL NOTE: Tags aren't available immediately!
+				-- Must use a timer to wait 100-500ms for BASS to parse metadata during stream init
+				timer.simple( 0.3, function()					
+					-- Try all tag formats (BASS auto-detects format)
+					local tags = snd:getTagsID3()		-- ID3v1 only (NOT ID3v2)
+					if not tags or not next(tags) then
+						tags = snd:getTagsOGG()		-- OGG Vorbis comments
+					end
+					if not tags or not next(tags) then
+						tags = snd:getTagsMP4()		-- MP4/M4A metadata
+					end
+					if not tags or not next(tags) then
+						tags = snd:getTagsWMA()		-- WMA metadata
+					end
+
+					-- For Shoutcast/Icecast streams:
+					local icyMeta = snd:getTagsMeta()		-- ICY metadata (e.g., "Artist - Title")
+					local icyHeaders = snd:getTagsHTTP()	-- HTTP headers (icy-name, icy-genre, etc.)
+
+					-- Display results
+					if tags and next(tags) then
+						print("Tags found:")
+						for k, v in pairs(tags) do
+							print(string.format("  %s: %s", k, v))
+						end
+					elseif icyMeta and icyMeta ~= "" then
+						print("Stream metadata:", icyMeta)
+						if icyHeaders then
+							print("   Station:", icyHeaders["icy-name"] or "Unknown")
+							print("   Genre:", icyHeaders["icy-genre"] or "Unknown")
+						end
+					else print("No tags found (may be ID3v2-only file or unsupported format)") end
+
+					-- Optional: Show technical info
+					print(string.format("Duration: %.1fs | Bitrate: %d kbps | Sample rate: %d Hz | Bits per sample: %d | Is Block Streamed: %s | Pitch: %d",
+						snd:getBufferedTime(),
+						snd:getFileName(),
+						snd:getAverageBitRate(),
+						snd:getSamplingRate(),
+						snd:getBitsPerSample(),
+						snd:isBlockStreamed(),
+						snd:getPitch()
+					))
+				end )
 
 				hook.add("think", "snd", function()
 					if isValid(snd) and isValid(chip()) then

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -583,7 +583,7 @@ return function(instance)
 		checkluatype(enable, TYPE_BOOLEAN)
 
 		local uw = getsnd(self)
-		if !uw:Is3D() then
+		if not uw:Is3D() then
 			SF.Throw("You cannot set the mode of a Bass Object that isn't 3D! Please call is3D first!!", 2)
 		end
 		uw:Set3DEnabled(enable)

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -334,6 +334,12 @@ return function(instance)
 		getsnd(self):SetPlaybackRate(math.Clamp(pitch, 0, 100))
 	end
 
+	--- Gets the pitch of the sound.
+	-- @param number The current pitch of the sound.
+	function bass_methods:getPitch()
+		return getsnd(self):GetPlaybackRate()
+	end
+
 	--- Sets the position of the sound in 3D space. Must have `3d` flag for this to have any effect.
 	-- @param Vector pos Where to position the sound.
 	function bass_methods:setPos(pos)
@@ -412,6 +418,12 @@ return function(instance)
 		return getsnd(self):GetTime()
 	end
 
+	--- Returns the filename for the sound channel.
+	-- @return string The file name. This will not be always what you have put into the Bass:loadURL() as first argument.
+	function bass_methods:getFileName()
+		return getsnd(self):GetFileName()
+	end
+
 	--- Perform fast Fourier transform algorithm to compute the DFT of the sound.
 	-- @param number n Number of consecutive audio samples, between 0 and 7. Depending on this parameter you will get 256*2^n samples.
 	-- @return table Table containing DFT magnitudes, each between 0 and 1.
@@ -419,6 +431,14 @@ return function(instance)
 		local arr = {}
 		getsnd(self):FFT(arr, n)
 		return arr
+	end
+
+	--- Returns whether the audio stream is block streamed or not.
+	-- @return boolean Is the audio stream block streamed or not.
+	function bass_methods:isBlockStreamed()
+		local uw = getsnd(self)
+		if !uw:IsOnline() then SF.Throw("The Bass Object isn't playing an online audio stream!", 2) end
+		return uw:IsBlockStreamed()
 	end
 
 	--- Gets whether the sound is streamed online.
@@ -447,7 +467,7 @@ return function(instance)
 	end
 
 	--- Sets the relative volume of the left and right channels.
-	-- @param number Relative integer volume between the left and right channels. Values must be -1 to 1 for relative left to right.
+	-- @param number pan Relative integer volume between the left and right channels. Values must be -1 to 1 for relative left to right.
 	function bass_methods:setPan(pan)
 		checkluatype(pan, TYPE_NUMBER)
 
@@ -472,6 +492,72 @@ return function(instance)
 		return getsnd(self):GetAverageBitRate()
 	end
 
+	--- Returns the buffered time of the sound channel in seconds, for online streaming sound channels (Bass:loadURL()). For offline channels this will be equivalent to Bass:getLength().
+	-- @return number The current buffered time of the stream, in seconds.
+	function bass_methods:getBufferedTime()
+		local uw = getsnd(self)
+		if uw:IsOnline() then
+			return uw:GetBufferedTime()
+		else return uw:GetLength() end
+	end
+
+	--- Returns the sample rate for currently playing sound.
+	-- @return number The sample rate in Hz. This should always be 44100.
+	function bass_methods:getSamplingRate()
+		return getsnd(self):GetSamplingRate()
+	end
+
+	--- Retrieves HTTP headers from a bass stream channel created by Bass:loadURL(), if available.
+	--- Of special interest here are headers such as icy-name, icy-br, ice-audio-info, icy-genre.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return table<string> A list of HTTP headers or nil if no information is available.
+	function bass_methods:getTagsHTTP()
+		return getsnd(self):GetTagsHTTP()
+	end
+
+	--- Retrieves the ID3 version 1 info from a bass channel created by Bass:loadFile or Bass:loadURL, if available. ID3v2 is not supported.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return table A table containing the information, or nil if no information is available.
+	-- (The table will always have the following keys, filled out based on what is available: "album", "artist", "comment", "genre", "id", "title", "year")
+	function bass_methods:getTagsID3()
+		return getsnd(self):GetTagsID3()
+	end
+
+	--- Retrieves ICY metadata from a bass stream channel created by Bass:loadURL, if available.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return string The meta information, or nil if no information is available.
+	function bass_methods:getTagsMeta()
+		return getsnd(self):GetTagsMeta()
+	end
+
+	--- Retrieves .m4a media info, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return table<string> A list of available information in no particular order, or nil if no information is available.
+	function bass_methods:getTagsMP4()
+		return getsnd(self):GetTagsMP4()
+	end
+
+	--- Retrieves OGG media info tag, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return table<string> A list of available information in no particular order, or nil if no information is available. 
+	function bass_methods:getTagsOGG()
+		return getsnd(self):GetTagsOGG()
+	end
+
+	--- Retrieves OGG Vendor tag, usually containing the application that created the file, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return string The OGG vendor tag, or nil if no information is available.
+	function bass_methods:getTagsVendor()
+		return getsnd(self):GetTagsVendor()
+	end
+
+	--- Retrieves .WMA media info, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
+	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
+	-- @return table<string> A list of available information in no particular order, or nil if no information is available.
+	function bass_methods:getTagsWMA()
+		return getsnd(self):GetTagsWMA()
+	end
+
 	--- Returns the flags used to create the sound.
 	-- @return string The flags of the sound (`3d`, `mono`, `noplay`, `noblock`).
 	function bass_methods:getFlags()
@@ -488,6 +574,23 @@ return function(instance)
 	-- @return boolean True if the sound is 3D.
 	function bass_methods:is3D()
 		return getsnd(self):Is3D()
+	end
+
+	--- Sets the 3D mode of the channel. This will affect Bass:set3DEnabled() but not Bass:is3D().
+	--- This feature requires the channel to be initially created in 3D mode, i.e. Bass:is3D() should return true or this function will do nothing. 
+	-- @return boolean enable True or False to toggle 3D.
+	function bass_methods:set3DEnabled(enable)
+		checkluatype(enable, TYPE_BOOLEAN)
+
+		local uw = getsnd(self)
+		if !uw:Is3D() then SF.Throw("You cannot set the mode of a Bass Object that isn't 3D! Please call is3D first!!", 2) end
+		uw:Set3DEnabled(enable)
+	end
+
+	--- Returns if the sound channel is currently in 3D mode or not. This value will be affected by Bass:set3DEnabled().
+	-- @return boolean True or False depending on if the sound is currently 3D or not.
+	function bass_methods:get3DEnabled()
+		return getsnd(self):Get3DEnabled()
 	end
 
 	--- Returns the state of the sound.
@@ -520,4 +623,28 @@ return function(instance)
 	function bass_methods:isStalled()
 		return getsnd(self):GetState() == GMOD_CHANNEL_STALLED
 	end
+
+	--- Sets 3D cone of the sound channel.
+	-- @param number innerAngle The angle of the inside projection cone in degrees. Range is from 0 (no cone) to 360 (sphere), -1 = leave current.
+	-- @param number outerAngle The angle of the outside projection cone in degrees. Range is from 0 (no cone) to 360 (sphere), -1 = leave current.
+	-- @param number outerVolume The delta-volume outside the outer projection cone. Range is from 0 (silent) to 1 (same as inside the cone), less than 0 = leave current.
+	function bass_methods:set3DCone(innerAngle, outerAngle, outerVolume)
+		checkluatype(innerAngle, TYPE_NUMBER)
+		checkluatype(outerAngle, TYPE_NUMBER)
+		checkluatype(outerVolume, TYPE_NUMBER)
+
+		local uw = getsnd(self)
+		-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled.
+		if !uw:Is3D() then SF.Throw("You cannot set the cone of a Bass Object that isn't 3D!", 2) end
+		uw:Set3DCone( innerAngle, outerAngle, outerVolume )
+	end
+
+	--- Returns 3D cone of the sound channel.
+	-- @return number The angle of the inside projection cone in degrees.
+	-- @return number The angle of the outside projection cone in degrees.
+	-- @return number The delta-volume outside the outer projection cone.
+	function bass_methods:get3DCone()
+		return getsnd(self):Get3DCone()
+	end
+
 end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -578,7 +578,7 @@ return function(instance)
 
 	--- Sets the 3D mode of the channel. This will affect Bass:set3DEnabled() but not Bass:is3D().
 	--- This feature requires the channel to be initially created in 3D mode, i.e. Bass:is3D() should return true or this function will do nothing. 
-	-- @return boolean enable True or False to toggle 3D.
+	-- @param boolean enable True or False to toggle 3D.
 	function bass_methods:set3DEnabled(enable)
 		checkluatype(enable, TYPE_BOOLEAN)
 

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -335,7 +335,7 @@ return function(instance)
 	end
 
 	--- Gets the pitch of the sound.
-	-- @param number The current pitch of the sound.
+	-- @return number The current pitch of the sound.
 	function bass_methods:getPitch()
 		return getsnd(self):GetPlaybackRate()
 	end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -437,7 +437,7 @@ return function(instance)
 	-- @return boolean Is the audio stream block streamed or not.
 	function bass_methods:isBlockStreamed()
 		local uw = getsnd(self)
-		if !uw:IsOnline() then SF.Throw("The Bass Object isn't playing an online audio stream!", 2) end
+		if not uw:IsOnline() then SF.Throw("The Bass Object isn't playing an online audio stream!", 2) end
 		return uw:IsBlockStreamed()
 	end
 
@@ -510,7 +510,7 @@ return function(instance)
 	--- Retrieves HTTP headers from a bass stream channel created by Bass:loadURL(), if available.
 	--- Of special interest here are headers such as icy-name, icy-br, ice-audio-info, icy-genre.
 	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
-	-- @return table<string> A list of HTTP headers or nil if no information is available.
+	-- @return table A list of HTTP headers or nil if no information is available.
 	function bass_methods:getTagsHTTP()
 		return getsnd(self):GetTagsHTTP()
 	end
@@ -532,14 +532,14 @@ return function(instance)
 
 	--- Retrieves .m4a media info, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
 	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
-	-- @return table<string> A list of available information in no particular order, or nil if no information is available.
+	-- @return table A list of available information in no particular order, or nil if no information is available.
 	function bass_methods:getTagsMP4()
 		return getsnd(self):GetTagsMP4()
 	end
 
 	--- Retrieves OGG media info tag, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
 	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
-	-- @return table<string> A list of available information in no particular order, or nil if no information is available. 
+	-- @return table A list of available information in no particular order, or nil if no information is available. 
 	function bass_methods:getTagsOGG()
 		return getsnd(self):GetTagsOGG()
 	end
@@ -553,7 +553,7 @@ return function(instance)
 
 	--- Retrieves .WMA media info, from a bass channel created by Bass:loadFile or Bass:loadURL, if available.
 	--- CRITICAL NOTE: Tags aren't available immediately! Must use a timer to wait 100-500ms for BASS to parse metadata during stream init!!
-	-- @return table<string> A list of available information in no particular order, or nil if no information is available.
+	-- @return table A list of available information in no particular order, or nil if no information is available.
 	function bass_methods:getTagsWMA()
 		return getsnd(self):GetTagsWMA()
 	end
@@ -583,7 +583,9 @@ return function(instance)
 		checkluatype(enable, TYPE_BOOLEAN)
 
 		local uw = getsnd(self)
-		if !uw:Is3D() then SF.Throw("You cannot set the mode of a Bass Object that isn't 3D! Please call is3D first!!", 2) end
+		if !uw:Is3D() then
+			SF.Throw("You cannot set the mode of a Bass Object that isn't 3D! Please call is3D first!!", 2)
+		end
 		uw:Set3DEnabled(enable)
 	end
 
@@ -635,7 +637,9 @@ return function(instance)
 
 		local uw = getsnd(self)
 		-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled.
-		if !uw:Is3D() then SF.Throw("You cannot set the cone of a Bass Object that isn't 3D!", 2) end
+		if not uw:Is3D() then
+			SF.Throw("You cannot set the cone of a Bass Object that isn't 3D!", 2)
+		end
 		uw:Set3DCone( innerAngle, outerAngle, outerVolume )
 	end
 

--- a/lua/starfall/libs_cl/file.lua
+++ b/lua/starfall/libs_cl/file.lua
@@ -698,4 +698,11 @@ return function(instance)
 		checkluatype(x, TYPE_STRING)
 		unwrap(self):WriteUInt64(x)
 	end
+
+	--- Returns whether the File object has reached the end of file or not.
+	-- @return boolean Whether the file has reached end or not.
+	function file_methods:endOfFile()
+		return unwrap(self):EndOfFile()
+	end
+
 end


### PR DESCRIPTION
Parody with [recent PR](https://github.com/thegrb93/StarfallEx/pull/2267) to old StarfallEx
A feature implementation of [#2266](https://github.com/thegrb93/StarfallEx/issues/2266).

## Changes
- Adds missing [IGModAudioChannel](https://wiki.facepunch.com/gmod/IGModAudioChannel) methods to BASS. (Basically you can now get ID3v1 tag metadata from MP3 files and other audio formats)
- Adds missing [endOfFile](https://wiki.facepunch.com/gmod/File:EndOfFile) method from glua to nsf.
- Updated example to reflect new feature additions
*That's pretty much it tbh*

![gm_construct0001](https://github.com/user-attachments/assets/c5d59997-1d59-43af-bf0e-d970dcdadd33)

<hr>

**Note:** Yes, I'm aware it is a little odd to be making PRs for both but I honest to god didn't know about NSF until recently and it dawned on me that I should also do a clone of my PR on StarfallEx over here because as it stands I believe NeoStarfall still isn't very popular?