### PR TITLE
Fix BASS calcFade

### DIFF
--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -43,7 +43,7 @@ local bassSound = {
 	__index = {
 		calcFade = function(self)
 			local fadeMult
-			local distSqr = self.sound:GetPos():DistToSqr(EyePos())
+			local distSqr = self.sound:GetPos():DistToSqr(MainEyePos())
 			if distSqr <= self.fadeMin * self.fadeMin then
 				fadeMult = 1
 			elseif distSqr >= self.fadeMax * self.fadeMax then


### PR DESCRIPTION
EyePos() is not a reliable way to get the eye position outside of render hooks. If EyePos is never called, the bass fade origin defaults to 0,0,0

## Changes

EyePos() -> MainEyePos()