### PR TITLE
fix bug in SF.GetExecutingPath()

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -2349,7 +2349,7 @@ function SF.GetExecutingPath()
 			break
 		end
 
-		curdir = string.match(info.short_src, "^SF:(.*)")
+		curdir = string.match(info.short_src, "^NSF:(.*)")
 		stackLevel = stackLevel + 1
 	until curdir
 	return curdir


### PR DESCRIPTION
fix the pattern in function SF.GetExecutingPath()